### PR TITLE
Accept NODENV_VERSIONs with 'v' prefix

### DIFF
--- a/libexec/nodenv-version-name
+++ b/libexec/nodenv-version-name
@@ -20,6 +20,8 @@ version_exists() {
 
 if version_exists "$NODENV_VERSION"; then
   echo "$NODENV_VERSION"
+elif version_exists "${NODENV_VERSION/v/}"; then
+  echo "${NODENV_VERSION/v/}"
 elif version_exists "${NODENV_VERSION#node-}"; then
   echo "${NODENV_VERSION#node-}"
 else

--- a/libexec/nodenv-version-name
+++ b/libexec/nodenv-version-name
@@ -24,6 +24,8 @@ elif version_exists "${NODENV_VERSION/v/}"; then
   echo "${NODENV_VERSION/v/}"
 elif version_exists "${NODENV_VERSION#node-}"; then
   echo "${NODENV_VERSION#node-}"
+elif version_exists "${NODENV_VERSION#node-v}"; then
+  echo "${NODENV_VERSION#node-v}"
 else
   echo "nodenv: version \`$NODENV_VERSION' is not installed (set by $(nodenv-version-origin))" >&2
   exit 1

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -68,6 +68,14 @@ setup() {
   assert_output "4.1.0"
 }
 
+@test "version with 'node-v' prefix in name" {
+  create_version "4.1.0"
+  cat > ".node-version" <<<"node-v4.1.0"
+  run nodenv-version-name
+  assert_success
+  assert_output "4.1.0"
+}
+
 @test "iojs version with 'v' prefix in name" {
   create_version "iojs-3.1.0"
   cat > ".node-version" <<<"iojs-v3.1.0"

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -59,3 +59,19 @@ setup() {
   assert_success
   assert_output "1.8.7"
 }
+
+@test "version with 'v' prefix in name" {
+  create_version "4.1.0"
+  cat > ".node-version" <<<"v4.1.0"
+  run nodenv-version-name
+  assert_success
+  assert_output "4.1.0"
+}
+
+@test "iojs version with 'v' prefix in name" {
+  create_version "iojs-3.1.0"
+  cat > ".node-version" <<<"iojs-v3.1.0"
+  run nodenv-version-name
+  assert_success
+  assert_output "iojs-3.1.0"
+}


### PR DESCRIPTION
for node versions, we already accept exact matches as well as the 'node-' prefix:

`NODENV_VERSION=0.10.36` -> `0.10.36`
`NODENV_VERSION=node-0.10.36` -> `0.10.36`
`NODENV_VERSION=iojs-1.0.0` -> `iojs-1.0.0`

now we accept an optional 'v' prefix in the version name:

`NODENV_VERSION=v0.10.36` -> `0.10.36`
`NODENV_VERSION=node-v0.10.36` -> `0.10.36`
`NODENV_VERSION=iojs-v1.0.0` -> `iojs-1.0.0`

(this also applies to `.node-version` files as well, to be clear)

closes #22