### PR TITLE
Latest updates from rbenv upstream

### DIFF
--- a/libexec/nodenv
+++ b/libexec/nodenv
@@ -12,39 +12,42 @@ if [ -n "$NODENV_DEBUG" ]; then
   set -x
 fi
 
+abort() {
+  { if [ "$#" -eq 0 ]; then cat -
+    else echo "nodenv: $*"
+    fi
+  } >&2
+  exit 1
+}
+
 if enable -f "${BASH_SOURCE%/*}"/../libexec/nodenv-realpath.dylib realpath 2>/dev/null; then
   abs_dirname() {
     local path="$(realpath "$1")"
     echo "${path%/*}"
   }
 else
-  if [ -n "$NODENV_NATIVE_EXT" ]; then
-    echo "nodenv: failed to load \`realpath' builtin" >&2
-    exit 1
-  fi
-READLINK=$(type -p greadlink readlink | head -1)
-if [ -z "$READLINK" ]; then
-  echo "nodenv: cannot find readlink - are you missing GNU coreutils?" >&2
-  exit 1
-fi
+  [ -z "$NODENV_NATIVE_EXT" ] || abort "failed to load \`realpath' builtin"
 
-resolve_link() {
-  $READLINK "$1"
-}
+  READLINK=$(type -p greadlink readlink | head -1)
+  [ -n "$READLINK" ] || abort "cannot find readlink - are you missing GNU coreutils?"
 
-abs_dirname() {
-  local cwd="$(pwd)"
-  local path="$1"
+  resolve_link() {
+    $READLINK "$1"
+  }
 
-  while [ -n "$path" ]; do
-    cd "${path%/*}"
-    local name="${path##*/}"
-    path="$(resolve_link "$name" || true)"
-  done
+  abs_dirname() {
+    local cwd="$PWD"
+    local path="$1"
 
-  pwd
-  cd "$cwd"
-}
+    while [ -n "$path" ]; do
+      cd "${path%/*}"
+      local name="${path##*/}"
+      path="$(resolve_link "$name" || true)"
+    done
+
+    pwd
+    cd "$cwd"
+  }
 fi
 
 if [ -z "${NODENV_ROOT}" ]; then
@@ -55,13 +58,10 @@ fi
 export NODENV_ROOT
 
 if [ -z "${NODENV_DIR}" ]; then
-  NODENV_DIR="$(pwd)"
+  NODENV_DIR="$PWD"
 else
-  cd "$NODENV_DIR" 2>/dev/null || {
-    echo "nodenv: cannot change working directory to \`$NODENV_DIR'"
-    exit 1
-  } >&2
-  NODENV_DIR="$(pwd)"
+  cd "$NODENV_DIR" 2>/dev/null || abort "cannot change working directory to \`$NODENV_DIR'"
+  NODENV_DIR="$PWD"
   cd "$OLDPWD"
 fi
 export NODENV_DIR
@@ -91,20 +91,26 @@ shopt -u nullglob
 
 command="$1"
 case "$command" in
-"" | "-h" | "--help" )
-  echo -e "$(nodenv---version)\n$(nodenv-help)" >&2
+"" )
+  { nodenv---version
+    nodenv-help
+  } | abort
   ;;
-"-v" )
+-v | --version )
   exec nodenv---version
+  ;;
+-h | --help )
+  exec nodenv-help
   ;;
 * )
   command_path="$(command -v "nodenv-$command" || true)"
-  if [ -z "$command_path" ]; then
-    echo "nodenv: no such command \`$command'" >&2
-    exit 1
-  fi
+  [ -n "$command_path" ] || abort "no such command \`$command'"
 
   shift 1
-  exec "$command_path" "$@"
+  if [ "$1" = --help ]; then
+    exec nodenv-help "$command"
+  else
+    exec "$command_path" "$@"
+  fi
   ;;
 esac

--- a/libexec/nodenv-completions
+++ b/libexec/nodenv-completions
@@ -10,7 +10,16 @@ if [ -z "$COMMAND" ]; then
   exit 1
 fi
 
+# Provide nodenv completions
+if [ "$COMMAND" = "--complete" ]; then
+  exec nodenv-commands
+fi
+
 COMMAND_PATH="$(command -v "nodenv-$COMMAND" || command -v "nodenv-sh-$COMMAND")"
+
+# --help is provided automatically
+echo --help
+
 if grep -iE "^([#%]|--|//) provide nodenv completions" "$COMMAND_PATH" >/dev/null; then
   shift
   exec "$COMMAND_PATH" --complete "$@"

--- a/libexec/nodenv-help
+++ b/libexec/nodenv-help
@@ -15,6 +15,12 @@
 set -e
 [ -n "$NODENV_DEBUG" ] && set -x
 
+# Provide nodenv completions
+if [ "$1" = "--complete" ]; then
+  echo --usage
+  exec nodenv-commands
+fi
+
 command_path() {
   local command="$1"
   command -v nodenv-"$command" || command -v nodenv-sh-"$command" || true

--- a/libexec/nodenv-init
+++ b/libexec/nodenv-init
@@ -5,6 +5,17 @@
 set -e
 [ -n "$NODENV_DEBUG" ] && set -x
 
+# Provide nodenv completions
+if [ "$1" = "--complete" ]; then
+  echo -
+  echo --no-rehash
+  echo bash
+  echo fish
+  echo ksh
+  echo zsh
+  exit
+fi
+
 print=""
 no_rehash=""
 for args in "$@"

--- a/libexec/nodenv-versions
+++ b/libexec/nodenv-versions
@@ -9,8 +9,13 @@ set -e
 
 unset bare
 unset skip_aliases
+# Provide nodenv completions
 for arg; do
   case "$arg" in
+  --complete )
+    echo --bare
+    echo --skip-aliases
+    exit ;;
   --bare ) bare=1 ;;
   --skip-aliases ) skip_aliases=1 ;;
   * )

--- a/libexec/nodenv-which
+++ b/libexec/nodenv-which
@@ -51,7 +51,7 @@ done
 
 if [ -x "$NODENV_COMMAND_PATH" ]; then
   echo "$NODENV_COMMAND_PATH"
-elif ! [ -d "${NODENV_ROOT}/versions/${NODENV_VERSION}" ]; then
+elif [ "$NODENV_VERSION" != "system" ] && [ ! -d "${NODENV_ROOT}/versions/${NODENV_VERSION}" ]; then
   echo "nodenv: version \`$NODENV_VERSION' is not installed (set by $(nodenv-version-origin))" >&2
   exit 1
 else

--- a/test/completions.bats
+++ b/test/completions.bats
@@ -13,7 +13,7 @@ create_command() {
   create_command "nodenv-hello" "#!$BASH
     echo hello"
   run nodenv-completions hello
-  assert_success ""
+  assert_success "--help"
 }
 
 @test "command with completion support" {
@@ -25,7 +25,11 @@ else
   exit 1
 fi"
   run nodenv-completions hello
-  assert_success "hello"
+  assert_success
+  assert_output <<OUT
+--help
+hello
+OUT
 }
 
 @test "forwards extra arguments" {
@@ -40,6 +44,7 @@ fi"
   run nodenv-completions hello happy world
   assert_success
   assert_output <<OUT
+--help
 happy
 world
 OUT

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -20,6 +20,14 @@ create_executable() {
   assert_failure "nodenv: version \`2.0' is not installed (set by NODENV_VERSION environment variable)"
 }
 
+@test "fails with invalid version set from file" {
+  mkdir -p "$NODENV_TEST_DIR"
+  cd "$NODENV_TEST_DIR"
+  echo 1.9 > .node-version
+  run nodenv-exec npm
+  assert_failure "nodenv: version \`1.9' is not installed (set by $PWD/.node-version)"
+}
+
 @test "completes with names of executables" {
   export NODENV_VERSION="2.0"
   create_executable "node" "#!/bin/sh"
@@ -29,6 +37,7 @@ create_executable() {
   run nodenv-completions exec
   assert_success
   assert_output <<OUT
+--help
 node
 npm
 OUT

--- a/test/nodenv.bats
+++ b/test/nodenv.bats
@@ -4,9 +4,8 @@ load test_helper
 
 @test "blank invocation" {
   run nodenv
-  assert_success
-  # assert line starts with
-  assert [ "${lines[0]}" != "${lines[0]#nodenv 0.4.0}" ]
+  assert_failure
+  assert_line 0 "$(nodenv---version)"
 }
 
 @test "invalid command" {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -39,7 +39,7 @@ teardown() {
 # but in which system utils necessary for nodenv operation are still available.
 path_without() {
   local exe="$1"
-  local path="${PATH}:"
+  local path=":${PATH}:"
   local found alt util
   for found in $(which -a "$exe"); do
     found="${found%/*}"
@@ -51,8 +51,9 @@ path_without() {
           ln -s "${found}/$util" "${alt}/$util"
         fi
       done
-      path="${path/${found}:/${alt}:}"
+      path="${path/:${found}:/:${alt}:}"
     fi
   done
+  path="${path#:}"
   echo "${path%:}"
 }

--- a/test/which.bats
+++ b/test/which.bats
@@ -68,6 +68,12 @@ create_executable() {
   assert_failure "nodenv: node: command not found"
 }
 
+@test "no executable found for system version" {
+  export PATH="$(path_without "mocha")"
+  NODENV_VERSION=system run nodenv-which mocha
+  assert_failure "nodenv: mocha: command not found"
+}
+
 @test "executable found in other versions" {
   create_executable "1.8" "node"
   create_executable "1.9" "npm"


### PR DESCRIPTION
- use PWD var over pwd command

- indentation

- Extract `abort` helper function

- completions for rbenv-init

- consistent completions for rbenv-help

- completions for rbenv-completions

- completions for rbenv-versions

- add --help to subcommand completions

- handle --help for subcommands

- Fix argument handling in main `rbenv` command

    - Explicitly asking for help with `-h` or `--help` exits with 0 status
    and displays help on stdout.

    - Not providing any arguments to rbenv results in failure status and
    displays version and help on stderr.

- Fix broken version-dependent test

- Fix error message when command is not found for "system" version

    If `foo` didn't exist and `RBENV_VERSION=system rbenv which foo` was
    called, the error message used to be misleading:

        rbenv: version `system' is not installed

    Instead, have the error message simply say that the command was not found.

- Add test for version-origin when version not found in `rbenv-exec`

- add completion block for rbenv-help

- tests: fix path_without to handle /bin properly